### PR TITLE
Updated to_string() to strip NULLs

### DIFF
--- a/code/ibmmq/__init__.py
+++ b/code/ibmmq/__init__.py
@@ -206,6 +206,9 @@ def to_string(v, encoding=EncodingDefault.bytes_encoding):
     """
     if isinstance(v, bytes):
         try:
+            null_index = v.find(0)
+            if null_index != -1:
+                v = v[:null_index]
             return v.decode(encoding).strip()
         except UnicodeError:
             pass


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-mqi-python/DCO1.1.txt)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-mqi-python/CHANGELOG.md)
- [x]  You have completed the PR template below:

## What

The `ibmmq.to_string()` is updated to strip NULL terminators.

## How

Before doing decoding of bytes to string, a search is done for NULL. If found, the code decodes only the number of bytes up to the NULL byte.

## Testing

Tested on artificially crafted bytes array and on real data coming from queue manager

## Issues

Resolves the issue #10
